### PR TITLE
Authorizes transactions

### DIFF
--- a/app/controllers/admin/admins_controller.rb
+++ b/app/controllers/admin/admins_controller.rb
@@ -3,7 +3,6 @@ class Admin::AdminsController < ApplicationController
   before_filter :require_admin_signin
 
   def index
-    @viz_data = 0
     @admins = Admin.all
   end
 
@@ -16,12 +15,10 @@ class Admin::AdminsController < ApplicationController
   end
 
   def new
-    @viz_data = 0
     @admin = Admin.new
   end
 
   def edit
-    @viz_data = 0
     @admin = Admin.find(params[:id])
   end
 
@@ -50,13 +47,11 @@ class Admin::AdminsController < ApplicationController
   end
 
   def show_current
-    @viz_data = 0
     render 'admin/admins/show_current'
   end
 
   def edit_current
-    @viz_data = 0
-    render 'admin/admins/edit_current' #can make this form unhide rather than new pg in non-MVP
+    render 'admin/admins/edit_current'
   end
 
   def update_current

--- a/app/controllers/admin/kiosks_controller.rb
+++ b/app/controllers/admin/kiosks_controller.rb
@@ -43,7 +43,7 @@ class Admin::KiosksController < ApplicationController
     @kiosk = Kiosk.find params[:id]
   end
 
-  def update #MLM NOTES TO REFACTOR - Need different way to redirect user when approach from nested provider route vs top level route
+  def update
     kiosk = Kiosk.find(params[:id])
     if params[:provider_id]
       begin

--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -3,7 +3,6 @@ class Admin::SessionsController < ApplicationController
   before_action :require_admin_signin, :only =>:destroy
 
   def new
-    @viz_data = 0
     if admin_signed_in?
       redirect_to admin_dashboard_path
     else

--- a/app/controllers/admin/transactions_controller.rb
+++ b/app/controllers/admin/transactions_controller.rb
@@ -1,16 +1,19 @@
 class Admin::TransactionsController < ApplicationController
-  before_filter :require_admin_signin
   def create
-    if params[:transactions]
-      params[:transactions].each do |transaction_data|
-        if hub = Hub.find_by(location_id:transaction_data[:location_id])
-          hub.transactions.create(transaction_params(transaction_data))
-        else
-          Transaction.create(transaction_params(transaction_data))
+    if authorize_transaction
+      if params[:transactions]
+        params[:transactions].each do |transaction_data|
+          if hub = Hub.find_by(location_id:transaction_data[:location_id])
+            hub.transactions.create(transaction_params(transaction_data))
+          else
+            Transaction.create(transaction_params(transaction_data))
+          end
         end
       end
+      render text: "Thanks for sending a POST request. Payload: #{request.body.read}"
+    else
+      render text: "Authorization failed!"
     end
-    render text: "Thanks for sending a POST request. Payload: #{request.body.read}"
   end
 
   private

--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -4,7 +4,6 @@ class EmployeesController < ApplicationController
   before_filter :require_employee_signin
 
   def index
-    @viz_data = 0
     @employees = current_provider.employees.all
   end
 
@@ -20,12 +19,10 @@ class EmployeesController < ApplicationController
   end
 
   def new
-    @viz_data = 0
     @employee = Employee.new
   end
 
   def edit
-    @viz_data = 0
     @employee = Employee.find(params[:id])
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,7 +2,6 @@ class SessionsController < ApplicationController
   layout "login"
 
   def new
-    @viz_data = 0
     if employee_signed_in?
       @provider = Provider.find(current_employee.provider_id)
       redirect_to provider_dashboard_path

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -67,4 +67,9 @@ module ApplicationHelper
       redirect_to '/admin'
     end
   end
+
+  def authorize_transaction
+    admin = Admin.find_by(email: params[:email])
+    admin && admin.authenticate(params[:password]) ? true : false
+  end
 end

--- a/spec/controllers/admin_transactions_controller_spec.rb
+++ b/spec/controllers/admin_transactions_controller_spec.rb
@@ -10,27 +10,78 @@ end
 describe Admin::TransactionsController do
 
   describe 'POST transactions#create' do
-    let(:params) {{format: :json, transactions: [
-                {transaction_time:generate_date_from_last_six_months,
-                transaction_code: 20,
-                location_id: 1,
-                amount: 2 },
+    before do
+      @admin = Admin.create!(
+      name: "susteq",
+      email: "susteq@dbc.com",
+      password: "123456")
+    end
 
-                {transaction_time:generate_date_from_last_six_months,
-                transaction_code: 20,
-                location_id: 1,
-                amount:2}]
+    after do
+      admin = @admin.destroy
+    end
+
+    let(:params) {{format: :json,
+
+                  email:"susteq@dbc.com",
+                  password:"123456",
+
+                  transactions: [
+                    {transaction_time:generate_date_from_last_six_months,
+                    transaction_code: 20,
+                    location_id: 1,
+                    amount: 2 },
+
+                    {transaction_time:generate_date_from_last_six_months,
+                    transaction_code: 20,
+                    location_id: 1,
+                    amount:2}
+                  ]
                 }}
-      let(:headers) {{ 'CONTENT_TYPE' => 'application/json' }}
+    let(:bad_params) {{format: :json,
+
+                  email:"susteq@dbc.com",
+                  password:"12345678",
+
+                  transactions: [
+                    {transaction_time:generate_date_from_last_six_months,
+                    transaction_code: 20,
+                    location_id: 1,
+                    amount: 2 },
+
+                    {transaction_time:generate_date_from_last_six_months,
+                    transaction_code: 20,
+                    location_id: 1,
+                    amount:2}
+                  ]
+                }}
+
+    let(:headers) {{ 'CONTENT_TYPE' => 'application/json' }}
     it 'returns a successful status' do
       post :create
       assert_response :success
     end
 
-    it 'creates new transactions' do
+    it 'return a successful message when authorized' do
+      post :create, params, headers
+      expect(response.body).to include("Thanks for sending a POST request")
+    end
+
+    it 'returns a failure message when unauthorized' do
+      post :create, bad_params, headers
+      expect(response.body).to eq("Authorization failed!")
+    end
+
+    it 'creates new transactions when authorized' do
       expect{
         post :create, params, headers
       }.to change(Transaction, :count)
+    end
+
+    it 'does not create a new transactions when unauthorized' do
+      expect{
+        post :create, bad_params, headers
+      }.to_not change(Transaction, :count)
     end
 
     it 'associates new transactions with existing hubs (by location id)' do


### PR DESCRIPTION
Removes "require_admin_sign_in" filter from Transactions Controller and utilizes an authorize_transaction helper method instead that looks for log-in credentials (i.e.) email and password in the params string. It will only add new transaction if it is able to authenticate the email/password combo. 

I had some concern over sending email/password combo in the post request. However, from what I understand in my research into the issue, as long as they use https it should be alright with a post request.  

http://security.stackexchange.com/questions/33793/handling-passwords-in-a-web-application

@melissa-mccoy 
