### PR TITLE
adds uniqueness validations for transactions

### DIFF
--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -1,5 +1,6 @@
 class Transaction < ActiveRecord::Base
   belongs_to :transactable, polymorphic:true
+  validates_uniqueness_of :transaction_code, scope: [:location_id, :transaction_time]
   scope :credits_sold, -> { where(transaction_code: [20,21]) }
 
 end

--- a/spec/factories/transactions.rb
+++ b/spec/factories/transactions.rb
@@ -1,0 +1,16 @@
+require 'faker'
+
+def generate_date_from_last_six_months
+  year = 2014
+  month = rand(6)+4
+  day = rand(30)+1     #Pour one out for n/31/2014; no pressing reason to add in the logic.
+  DateTime.new(year, month, day)
+end
+
+FactoryGirl.define do
+  factory :transaction do
+    location_id {(0..9).to_a.sample}
+    transaction_code {(1..200).to_a.sample}
+    transaction_time {generate_date_from_last_six_months}
+  end
+end

--- a/spec/models/transaction_spec.rb
+++ b/spec/models/transaction_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../rails_helper'
+
+describe Transaction do
+  describe "checks for uniqueness of transactions" do
+    subject {build(:transaction)}
+    it {should validate_uniqueness_of(:transaction_code).scoped_to([:location_id, :transaction_time])}
+  end
+end


### PR DESCRIPTION
Per our conversation with Niels, I added a validation on the Transaction model that checks for uniqueness of new transactions based on the transaction_code scoped by location_id and transaction_time. This means that the validation will only check transactions that have have the same location_id and transaction_time when checking for uniqueness of the transaction_code. I also added model and controller tests to ensure that that this is functioning as expected with the Transaction Controller.
@melissa-mccoy 
