### PR TITLE
skips authenticity token for json requests

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,13 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+  skip_before_action :verify_authenticity_token, if: :json_request?
   include ApplicationHelper
   include PerspectiveSummary
+
+  protected
+
+  def json_request?
+    request.format.json?
+  end
 end


### PR DESCRIPTION
I skip the check for an authenticity token for incoming JSON request in order to allow Susteq to hit our transactions/new endpoint. This is at best a temporary measure.
