### PR TITLE
Fixes transaction_controller#create 

### DIFF
--- a/app/controllers/admin/transactions_controller.rb
+++ b/app/controllers/admin/transactions_controller.rb
@@ -1,8 +1,11 @@
 class Admin::TransactionsController < ApplicationController
+  skip_before_filter :verify_authenticity_token, :only => [:create]
+
   def create
     if authorize_transaction
       if params[:transactions]
         params[:transactions].each do |transaction_data|
+          transaction_data[:transaction_time] = Time.zone.at(transaction_data[:transaction_time])
           if hub = Hub.find_by(location_id:transaction_data[:location_id])
             hub.transactions.create(transaction_params(transaction_data))
           else

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,13 +2,6 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
-  skip_before_action :verify_authenticity_token, if: :json_request?
   include ApplicationHelper
   include PerspectiveSummary
-
-  protected
-
-  def json_request?
-    request.format.json?
-  end
 end


### PR DESCRIPTION
Moves skip_before_action :verify_authenticity_token from ApplicatonController to TransactionController and applies it only to create method. 

Adds a conversion from unix timestamp to datetime object in TransactionController#create method.
